### PR TITLE
Pop up styling

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -7,11 +7,13 @@
    min-height: 250px;
    display: flex;
    flex-flow: column;
+   background-color: #FFFFFF;
  }
 
 h3 {
   margin-top: 0;
   font-size: 130%;
+  margin-bottom: .3em;
 }
 
 strong {
@@ -22,7 +24,6 @@ strong {
 .jscolor {
   height: 40px;
   width: 40px;
-  margin-bottom: 8px;
   border: 2px solid #555;
   border-radius: 6px;
   color: transparent !important;
@@ -36,4 +37,42 @@ button {
   height: 30px;
   width: 30px;
   outline: none;
+}
+
+/* provides spacing between settings options and color definition */
+/* 16px border radius matches Duolingo's current styling */
+div.settings-option-wrapper {
+  background-color: #E3E3E3;
+  border-radius: 16px;
+  display:inline-block;
+  margin-top: .3em;
+}
+
+/* provides spacing between the inner contents of a settings and its outer defining edge */
+div.settings-option-inner {
+  margin-bottom: 4px;
+  margin-top: 4px;
+}
+
+/* flex box row styling */
+.row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+/* flex box column styling */
+.column {
+  display: flex;
+  flex-direction: column;
+  flex-basis: 100%;
+  flex: 1;
+  margin-right: 1em;
+}
+
+select#theme-family {
+  display: block;
+  margin-left: auto;
+  margin-right: auto; 
 }

--- a/popup.html
+++ b/popup.html
@@ -2,21 +2,47 @@
 <html>
   <body>
   <div id="popup-wrapper">
-    <h3>Colors:</h3>
-    <div><strong>Background - Outer</strong><input id="colorBackgroundOut" class="jscolor" type="text" value="ffffff" readonly></div>
-    <div><strong>Background - Inner</strong><input id="colorBackgroundIn" class="jscolor" type="text" value="ffffff" readonly></div>
-    <h3>Fonts:</h3>
-    <div>
-      <strong>Font type</strong>
-      <select id="fontFamily" class="fontFamily">
-        <option value="din-round">Standard</option>
-        <option value="Arial">Arial</option>
-        <option value="Impact">Impact</option>
-        <option value="Verdana">Verdana</option>
-        <option value="Futura">Futura</option>
-        <option value="Impact">Calibri</option>
-        <option value="Chalkboard">Chalkboard</option>
-      </select>
+    <div class="row">
+      <div class="column">
+        <h3>Colors:</h3>
+        <div class="settings-option-wrapper">
+          <div class="settings-option-inner">
+              <strong>Background - Outer</strong>
+              <input id="colorBackgroundOut" class="jscolor" type="text" value="ffffff" readonly>
+          </div>
+        </div>
+        <div class="settings-option-wrapper">
+          <div class="settings-option-inner">
+              <strong>Background - Inner</strong>
+              <input id="colorBackgroundIn" class="jscolor" type="text" value="ffffff" readonly>
+          </div>
+        </div>
+        <h3 style="margin-top: .3em;">Fonts:</h3>
+        <div class="settings-option-wrapper">
+          <div class="settings-option-inner">
+              <strong>Font type</strong>
+              <select id="fontFamily" class="fontFamily">
+                <option value="din-round">Standard</option>
+                <option value="Arial">Arial</option>
+                <option value="Impact">Impact</option>
+                <option value="Verdana">Verdana</option>
+                <option value="Futura">Futura</option>
+                <option value="Impact">Calibri</option>
+                <option value="Chalkboard">Chalkboard</option>
+              </select>
+          </div>
+        </div>
+      </div>
+      <div class="column">
+        <h3>Themes:</h3>
+        <div class="settings-option-wrapper">
+          <div class="settings-option-inner">
+              <select id="theme-family">
+                  <option>Standby for themes</option>
+                </select>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   </body>


### PR DESCRIPTION
Hey there! So I've been trying to figure out how to apply styling to the Store button but haven't quite worked it out yet. Still working out how Chrome extensions run JS code.

However I got some styling done on the pop up window like you mentioned and figured it would be worth a small pull request to check this is on the path of what you want.

![Annotation 2019-04-13 174228](https://user-images.githubusercontent.com/17424089/56086406-f176e000-5e13-11e9-87d4-268b243cbf96.png)


Added some new HTML elements to organize the pop up and page and make future styling and expanding easier. A few new CSS rules to make some of the sections distinct and make room for any other options that need to be added.

If this looks good I can either dive into muting colors / developing themes or work on that store button. I imagine fleshing out some full site themes may be the most useful and Ill probably figure out how to style that button along the way.

Feel free to open issues or create projects on your repo if you have specific idea you want fleshed out. 